### PR TITLE
Fix underflow and out of bounds errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ fn draw_lines(
         if lines.lines[i].duration < 0.0 {
             lines.lines.swap(i, len - 1);
             len -= 1;
-            i -= 1;
+            i = i.saturating_sub(1);
         }
 
         i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ fn draw_lines(
 
     let mut i = 0;
     let mut len = lines.lines.len();
-    while i != len {
+    while i < len {
         lines.lines[i].duration -= time.delta_seconds();
         if lines.lines[i].duration < 0.0 {
             lines.lines.swap(i, len - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,10 +274,9 @@ fn draw_lines(
         if lines.lines[i].duration < 0.0 {
             lines.lines.swap(i, len - 1);
             len -= 1;
-            i = i.saturating_sub(1);
+        } else {
+            i += 1;
         }
-
-        i += 1;
     }
 
     lines.lines.truncate(len);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ fn draw_lines(
 
     let mut i = 0;
     let mut len = lines.lines.len();
-    while i < len {
+    while i != len {
         lines.lines[i].duration -= time.delta_seconds();
         if lines.lines[i].duration < 0.0 {
             lines.lines.swap(i, len - 1);


### PR DESCRIPTION
While fixing the underflow bug I also found that sometimes an out of bound error also occurs. I've included a fix for that too but I'm not 100% if this fix is correct as I don't have a small reproduction for it. I believe this out of bounds error occurs when there all remaining lines are removed in a single frame, bring the line count down to zero.

Fixes #3
