### PR TITLE
Make lines drawn the same frame they are called

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code)]
 
 use bevy::prelude::*;
-use bevy::render::RenderStage;
 use bevy::render::{
     mesh::VertexAttributeValues,
     pipeline::{ PrimitiveTopology, PipelineDescriptor, RenderPipeline, PrimitiveState, CullMode  },
@@ -54,8 +53,8 @@ impl Plugin for DebugLinesPlugin {
             .add_asset::<LineShader>()
             .init_resource::<DebugLines>()
             .add_startup_system(setup.system())
-            .add_system_to_stage(CoreStage::Last, draw_lines.system().label("draw_lines"))
-            .add_system_to_stage(CoreStage::Last, asset_shader_defs_system::<LineShader>.system().before("draw_lines"));
+            .add_system_to_stage(CoreStage::PostUpdate, draw_lines.system().label("draw_lines"))
+            .add_system_to_stage(CoreStage::PostUpdate, asset_shader_defs_system::<LineShader>.system().before("draw_lines"));
     }
 }
 


### PR DESCRIPTION
While working on some updates to [Rusty Engine](https://github.com/CleanCut/rusty_engine/issues/16) I started using this plugin to draw debug lines representing the colliders on my sprites. Since the sprites were in motion, I noticed that the debug lines were consistently drawn 1 frame later, which was annoying.

After poking around a bit, I found that if you move the systems from `CoreStage::Last` to `CoreStage::PostUpdate`, then they were drawn in the same frame!  This is _much_ nicer.

I have tested this only with the release version of Bevy 0.5. 