### PR TITLE
Bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.6.1"
 exclude = ["demo.gif", "demo_2.png", "demo_2.webm"]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = [ "render" ] }
+bevy = { version = "0.6", default-features = false, features = [ "bevy_core_pipeline", "bevy_render", "bevy_pbr", "bevy_sprite" ] }
 
 [features]
 example_deps_2d = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.6.1"
 exclude = ["demo.gif", "demo_2.png", "demo_2.webm"]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = [ "bevy_core_pipeline", "bevy_render", "bevy_pbr", "bevy_sprite" ] }
+bevy = { version = "0.7", default-features = false, features = [ "bevy_core_pipeline", "bevy_render", "bevy_pbr", "bevy_sprite" ] }
 
 [features]
 example_deps_2d = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl DebugLinesPlugin {
 
 impl Plugin for DebugLinesPlugin {
     fn build(&self, app: &mut App) {
-        use bevy::render::{render_resource::SpecializedPipelines, RenderApp, RenderStage};
+        use bevy::render::{render_resource::SpecializedMeshPipelines, RenderApp, RenderStage};
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             DEBUG_LINES_SHADER_HANDLE,
@@ -109,7 +109,7 @@ impl Plugin for DebugLinesPlugin {
             .add_render_command::<dim::Phase, dim::DrawDebugLines>()
             .insert_resource(DebugLinesConfig { depth_test: self.depth_test})
             .init_resource::<dim::DebugLinePipeline>()
-            .init_resource::<SpecializedPipelines<dim::DebugLinePipeline>>()
+            .init_resource::<SpecializedMeshPipelines<dim::DebugLinePipeline>>()
             .add_system_to_stage(RenderStage::Extract, extract)
             .add_system_to_stage(RenderStage::Queue, dim::queue);
 
@@ -135,11 +135,11 @@ fn setup(mut cmds: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     for i in 0..MESH_COUNT {
         // Create a new mesh with the number of vertices we need.
         let mut mesh = Mesh::new(PrimitiveTopology::LineList);
-        mesh.set_attribute(
+        mesh.insert_attribute(
             Mesh::ATTRIBUTE_POSITION,
             VertexAttributeValues::Float32x3(Vec::with_capacity(MAX_POINTS_PER_MESH)),
         );
-        mesh.set_attribute(
+        mesh.insert_attribute(
             Mesh::ATTRIBUTE_COLOR,
             VertexAttributeValues::Float32x4(Vec::with_capacity(MAX_POINTS_PER_MESH)),
         );


### PR DESCRIPTION
This PR contains two changes (separate commits) related to Bevy:

* Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202
* Update to Bevy 0.7. All changes comes from [this PR](https://github.com/bevyengine/bevy/pull/3959) in Bevy, which I used to get information about what changed. But currently it crashes with the following error:

```
thread 'main' panicked at 'range end index 176 out of range for slice of length 160', .cargo/registry/src/github.com-1ecc6299db9ec823/bevy_render-0.7.0/src/mesh/mesh/mod.rs:241:17
```

So the PR is draft.