### PR TITLE
Fix shader compiling error on wasm targets

### DIFF
--- a/src/debuglines2d.wgsl
+++ b/src/debuglines2d.wgsl
@@ -1,3 +1,5 @@
+#version 300 es
+
 #import bevy_sprite::mesh2d_view_bind_group
 [[group(0), binding(0)]]
 var<uniform> view: View;


### PR DESCRIPTION
Adding a required GL version of 3.0 fixes the following shader compiling error on wasm:

`'packUnorm2x16': no matching overloaded function found`