### PR TITLE
Render to layer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) struct DebugLinesConfig {
 
 #[derive(Resource)]
 pub(crate) struct DebugLinesRenderLayer {
-    render_layer: u8,
+    render_layers: Vec<u8>,
 }
 
 /// The `SystemSet` in which the debug lines update system runs.
@@ -106,10 +106,18 @@ pub enum DebugLinesSet {
 ///     .add_plugin(DebugLinesPlugin::with_depth_test(true))
 ///     .run();
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct DebugLinesPlugin {
     depth_test: bool,
-    render_layer: u8,
+    render_layers: Vec<u8>,
+}
+impl Default for DebugLinesPlugin {
+    fn default() -> Self {
+        Self {
+            depth_test: false,
+            render_layers: vec![0], // All entitities are renderered in layer 0 if not otherwise specified.
+        }
+    }
 }
 
 impl DebugLinesPlugin {
@@ -143,7 +151,7 @@ impl Plugin for DebugLinesPlugin {
         app.init_resource::<DebugShapes>();
 
         app.insert_resource(DebugLinesRenderLayer {
-            render_layer: self.render_layer,
+            render_layers: self.render_layers.to_owned(),
         });
 
         app.add_startup_system(setup).add_system(
@@ -203,7 +211,7 @@ fn setup(mut cmds: Commands, mut meshes: ResMut<Assets<Mesh>>, config: Res<Debug
             ComputedVisibility::default(),
             DebugLinesMesh(i),
             NoFrustumCulling, // disable frustum culling
-            RenderLayers::layer(config.render_layer),
+            RenderLayers::from_layers(config.render_layers.as_slice()),
         ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub enum DebugLinesSet {
 ///
 /// App::new()
 ///     .add_plugins(DefaultPlugins)
-///     .add_plugin(DebugLinesPlugin { render_layers: vec![0, 1, 5], ..default()})
+///     .add_plugin(DebugLinesPlugin::with_layers(vec![0, 1, 5]))
 ///     .run();
 /// ```
 #[derive(Debug, Clone)]
@@ -141,6 +141,20 @@ impl DebugLinesPlugin {
     pub fn with_depth_test(val: bool) -> Self {
         Self {
             depth_test: val,
+            ..default()
+        }
+    }
+
+    /// Controls which [`RenderLayers`] the debug line entity should belong to.
+    /// Cameras will only render entities on layers which intersect with the camera's own [`RenderLayers`] component.
+    /// If not specified, the debug line entity will be on layer 0 by default.
+    ///
+    /// # Arguments
+    ///
+    /// * `layers` - The list of rendering layers.
+    pub fn with_layers(layers: Vec<u8>) -> Self {
+        Self {
+            render_layers: layers,
             ..default()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,16 @@ pub enum DebugLinesSet {
 ///     .add_plugin(DebugLinesPlugin::with_depth_test(true))
 ///     .run();
 /// ```
+/// The [`RenderLayers`] to which lines will be drawn can also be specified.
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_prototype_debug_lines::*;
+///
+/// App::new()
+///     .add_plugins(DefaultPlugins)
+///     .add_plugin(DebugLinesPlugin { render_layers: vec![0, 1, 5], ..default()})
+///     .run();
+/// ```
 #[derive(Debug, Clone)]
 pub struct DebugLinesPlugin {
     depth_test: bool,


### PR DESCRIPTION
Resolves #35.

This change enables the configuration of which `RenderLayers` the line is drawn to. This enables drawing lines to a subset of cameras where there are multiple cameras displayed simultaneously (useful for editor tools).

Happy to make/allow any changes which better align the feature to the desired architecture of the plugin.