### PR TITLE
upgrade to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.10.2"
 exclude = ["demo.gif", "demo_2.png", "demo_2.webm"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [ "bevy_core_pipeline", "bevy_render", "bevy_pbr", "bevy_sprite", "bevy_asset" ] }
+bevy = { version = "0.11", default-features = false, features = [ "bevy_core_pipeline", "bevy_render", "bevy_pbr", "bevy_sprite", "bevy_asset" ] }
 
 [features]
 default = ["shapes"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use bevy_prototype_debug_lines::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
+        .add_plugins(DebugLinesPlugin::default())
 //      ...
         .run();
 }
@@ -60,7 +60,7 @@ use bevy_prototype_debug_lines::*;
 fn main() {
     App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugin(DebugLinesPlugin::with_depth_test(true))
+    .add_plugins(DebugLinesPlugin::with_depth_test(true))
 //  ...
     .run();
 }

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -14,15 +14,15 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(DebugLinesPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(LogDiagnosticsPlugin {
+        .add_plugins(DebugLinesPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(LogDiagnosticsPlugin {
             wait_duration: bevy::utils::Duration::new(5, 0),
             ..default()
         })
-        .add_startup_system(setup)
-        .add_system(demo_circle)
-        //.add_system(demo_block)
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo_circle)
+        //.add_systems(Update, demo_block)
         .run();
 }
 

--- a/examples/depth_test.rs
+++ b/examples/depth_test.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::with_depth_test(true))
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::with_depth_test(true))
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/movement.rs
+++ b/examples/movement.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(move_with_mouse)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_with_mouse)
         .run();
 }
 

--- a/examples/shapes_2d.rs
+++ b/examples/shapes_2d.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/shapes_3d.rs
+++ b/examples/shapes_3d.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/shapes_bench.rs
+++ b/examples/shapes_bench.rs
@@ -14,14 +14,14 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(DebugLinesPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(LogDiagnosticsPlugin {
+        .add_plugins(DebugLinesPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(LogDiagnosticsPlugin {
             wait_duration: bevy::utils::Duration::new(5, 0),
             ..default()
         })
-        .add_startup_system(setup)
-        .add_system(demo_circle)
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo_circle)
         .run();
 }
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -5,9 +5,9 @@ use bevy_prototype_debug_lines::{DebugLines, DebugLinesPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/examples/toggle_rendering.rs
+++ b/examples/toggle_rendering.rs
@@ -6,9 +6,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(DebugLinesPlugin::default())
-        .add_startup_system(setup)
-        .add_system(demo)
+        .add_plugins(DebugLinesPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, demo)
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub enum DebugLinesSet {
 ///
 /// App::new()
 ///     .add_plugins(DefaultPlugins)
-///     .add_plugin(DebugLinesPlugin::default())
+///     .add_plugins(DebugLinesPlugin::default())
 ///     .run();
 /// ```
 ///
@@ -103,7 +103,7 @@ pub enum DebugLinesSet {
 ///
 /// App::new()
 ///     .add_plugins(DefaultPlugins)
-///     .add_plugin(DebugLinesPlugin::with_depth_test(true))
+///     .add_plugins(DebugLinesPlugin::with_depth_test(true))
 ///     .run();
 /// ```
 /// The [`RenderLayers`] to which lines will be drawn can also be specified.
@@ -113,7 +113,7 @@ pub enum DebugLinesSet {
 ///
 /// App::new()
 ///     .add_plugins(DefaultPlugins)
-///     .add_plugin(DebugLinesPlugin::with_layers(vec![0, 1, 5]))
+///     .add_plugins(DebugLinesPlugin::with_layers(vec![0, 1, 5]))
 ///     .run();
 /// ```
 #[derive(Debug, Clone)]
@@ -178,11 +178,8 @@ impl Plugin for DebugLinesPlugin {
             render_layers: self.render_layers.to_owned(),
         });
 
-        app.add_startup_system(setup).add_system(
-            update
-                .in_base_set(CoreSet::PostUpdate)
-                .in_set(DebugLinesSet::DrawLines),
-        );
+        app.add_systems(Startup, setup)
+            .add_systems(PostUpdate, update.in_set(DebugLinesSet::DrawLines));
 
         app.sub_app_mut(RenderApp)
             .add_render_command::<dim::Phase, dim::DrawDebugLines>()
@@ -190,8 +187,8 @@ impl Plugin for DebugLinesPlugin {
                 depth_test: self.depth_test,
             })
             .init_resource::<SpecializedMeshPipelines<dim::DebugLinePipeline>>()
-            .add_system(extract.in_schedule(ExtractSchedule))
-            .add_system(dim::queue.in_set(RenderSet::Queue));
+            .add_systems(ExtractSchedule, extract)
+            .add_systems(Update, dim::queue.in_set(RenderSet::Queue));
 
         info!("Loaded {} debug lines plugin.", dim::DIMMENSION);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl Plugin for DebugLinesPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             DEBUG_LINES_SHADER_HANDLE,
-            Shader::from_wgsl(dim::SHADER_FILE),
+            Shader::from_wgsl(dim::SHADER_FILE, dim::SHADER_FILE),
         );
 
         app.init_resource::<DebugLines>();
@@ -189,12 +189,20 @@ impl Plugin for DebugLinesPlugin {
             .insert_resource(DebugLinesConfig {
                 depth_test: self.depth_test,
             })
-            .init_resource::<dim::DebugLinePipeline>()
             .init_resource::<SpecializedMeshPipelines<dim::DebugLinePipeline>>()
             .add_system(extract.in_schedule(ExtractSchedule))
             .add_system(dim::queue.in_set(RenderSet::Queue));
 
         info!("Loaded {} debug lines plugin.", dim::DIMMENSION);
+    }
+
+    // We can't add the pipeline to the app until after the render app has been initialized.
+    fn finish(&self, app: &mut App) {
+        use bevy::render::RenderApp;
+
+        app.get_sub_app_mut(RenderApp)
+            .unwrap()
+            .init_resource::<dim::DebugLinePipeline>();
     }
 }
 

--- a/src/render_dim.rs
+++ b/src/render_dim.rs
@@ -238,10 +238,7 @@ pub mod r2d {
     impl FromWorld for DebugLinePipeline {
         fn from_world(render_world: &mut World) -> Self {
             DebugLinePipeline {
-                mesh_pipeline: render_world
-                    .get_resource::<Mesh2dPipeline>()
-                    .unwrap()
-                    .clone(),
+                mesh_pipeline: Mesh2dPipeline::from_world(render_world),
                 shader: DEBUG_LINES_SHADER_HANDLE.typed(),
             }
         }


### PR DESCRIPTION
In addition to changing cargo.toml, I updated add_system/add_plugin calls to their new pluralized variants, changed the shader loading call & 2d pipeline initialization based on bevy's release notes.  The crate builds successfully and all doc tests pass.  Additionally, it continues to work within my own private (for now) repo.