### PR TITLE
Fix lines not showing after update to Bevy 0.11

### DIFF
--- a/src/debuglines.wgsl
+++ b/src/debuglines.wgsl
@@ -1,5 +1,5 @@
 // One shader should be possible, previously bugged so we use 2 shaders: https://github.com/bevyengine/bevy/issues/4011
-#import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::mesh_view_bindings view
 
 struct Vertex {
     @location(0) pos: vec3<f32>,

--- a/src/debuglines2d.wgsl
+++ b/src/debuglines2d.wgsl
@@ -1,4 +1,4 @@
-#import bevy_sprite::mesh2d_view_bindings
+#import bevy_sprite::mesh2d_view_bindings view
 
 
 struct Vertex {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use bevy::{
         render_resource::PrimitiveTopology,
         render_resource::Shader,
         view::{NoFrustumCulling, RenderLayers},
-        Extract,
+        Extract, Render,
     },
 };
 use shapes::AddLines;
@@ -188,7 +188,7 @@ impl Plugin for DebugLinesPlugin {
             })
             .init_resource::<SpecializedMeshPipelines<dim::DebugLinePipeline>>()
             .add_systems(ExtractSchedule, extract)
-            .add_systems(Update, dim::queue.in_set(RenderSet::Queue));
+            .add_systems(Render, dim::queue.in_set(RenderSet::Queue));
 
         info!("Loaded {} debug lines plugin.", dim::DIMMENSION);
     }

--- a/src/render_dim.rs
+++ b/src/render_dim.rs
@@ -49,13 +49,13 @@ pub mod r3d {
         ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
             let mut shader_defs = Vec::new();
             shader_defs.push("LINES_3D".into());
-            shader_defs.push(ShaderDefVal::Int(
+            shader_defs.push(ShaderDefVal::UInt(
                 "MAX_CASCADES_PER_LIGHT".to_string(),
-                MAX_CASCADES_PER_LIGHT as i32,
+                MAX_CASCADES_PER_LIGHT as u32,
             ));
-            shader_defs.push(ShaderDefVal::Int(
+            shader_defs.push(ShaderDefVal::UInt(
                 "MAX_DIRECTIONAL_LIGHTS".to_string(),
-                MAX_DIRECTIONAL_LIGHTS as i32,
+                MAX_DIRECTIONAL_LIGHTS as u32,
             ));
             if depth_test {
                 shader_defs.push("DEPTH_TEST_ENABLED".into());


### PR DESCRIPTION
Fix for issue #42

- Updated `queue` system to run in `Render` schedule.
- Updated shaders to import view: https://bevyengine.org/learn/migration-guides/0.10-0.11/#improve-shader-import-model
- Updated `MAX_CASCADES_PER_LIGHT` and `MAX_DIRECTIONAL_LIGHTS` to be of type `u32` instead of `i32`